### PR TITLE
Count redirected and returned parcels again

### DIFF
--- a/custom_components/nova_poshta/coordinator.py
+++ b/custom_components/nova_poshta/coordinator.py
@@ -118,16 +118,28 @@ class NovaPoshtaCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Retrieve delivered parcels for the warehouse id."""
         delivered = list(
             filter(
-                lambda x: x["TypeOfDocument"] == "Incoming"
+                lambda x: (x["TypeOfDocument"] == "Incoming" or x["OwnerDocumentType"])
                 and (x["TrackingStatusCode"] == "7" or x["TrackingStatusCode"] == "8"),
                 self.parcels,
+            )
+        )
+        # A redirect or a return to sender opens a second waybill for the same
+        # parcel, and Nova Poshta types it by who ordered the service ("Outgoing")
+        # rather than by where the parcel is going -- hence OwnerDocumentType above.
+        # Both waybills can sit at 7/8 at once, so keep only the leg that is live:
+        # a document naming a successor that is itself in the list is superseded.
+        numbers = set(map(lambda x: x["Number"], delivered))
+        latest = list(
+            filter(
+                lambda x: not any(ew["Number"] in numbers for ew in x["LinkedEWs"]),
+                delivered,
             )
         )
         return list(
             filter(
                 lambda x: x["SettlmentAddressData"]["RecipientWarehouseNumber"]
                 == warehouse_id,
-                delivered,
+                latest,
             )
         )
 


### PR DESCRIPTION
### Problem

A redirect («Переадресування») or a return to sender («Повернення») does not move the
existing waybill — Nova Poshta parks it and opens a **second** waybill for the new leg,
and it types that leg by who *ordered the service*, not by where the parcel is going.
Both come back from `getIncomingDocumentsByPhone`, and in the recipient's own feed they
look like this:

```
Number 5900…   TypeOfDocument "Outgoing"   OwnerDocumentType "Redirecting"
               TrackingStatusCode "7"      RecipientWarehouseNumber "341"   <- the parcel is here
               LinkedEWs []

Number 2040…   TypeOfDocument "Incoming"   OwnerDocumentType ""
               TrackingStatusCode "104"    RecipientWarehouseNumber "41193" <- old address
               LinkedEWs [{"Number": "5900…", "OwnerDocumentType": "Redirecting"}]
```

So the `TypeOfDocument == "Incoming"` test I added in #22 hides the leg that actually
arrives:

* a parcel redirected while still in transit leaves the original parked at 104 and is
  counted nowhere — it sits in the branch while the sensor reads 0;
* a returned parcel waiting at the branch is never counted either: its leg is
  `OwnerDocumentType: "CargoReturn"` and is also typed `Outgoing`, even in the feed of
  the recipient it is addressed to.

### Change

Accept a service-generated leg (non-empty `OwnerDocumentType`) beside the `Incoming`
documents, and keep the de-duplication #22 was doing by pairing the legs structurally
rather than by type: the parent waybill names its successor in `LinkedEWs`, so a
document whose successor is also in the list is superseded and dropped.

De-duplicating before the warehouse filter also fixes a case #22 gets wrong in the
other direction: a parcel that arrived at one warehouse and was redirected away
afterwards keeps being counted at the **old** warehouse, because the parent document
stays at 7/8 with its original `RecipientWarehouseNumber`.

### Checked against live data

Both filters run over real `getIncomingDocumentsByPhone` rows from two accounts,
with the statuses those waybills actually passed through:

| case | before | after |
| --- | --- | --- |
| redirect in transit (leg at 7, parent at 104) | 0 | 1, at the new warehouse |
| return to sender, waiting at the branch | 0 | 1 |
| both legs at 7/8 (the duplicate #22 fixed) | 1, at the parent's old warehouse | 1, at the new warehouse |
| ordinary incoming parcels | unchanged | unchanged |

`black --check --fast` is clean, and nothing changes for documents without an
`OwnerDocumentType`.

### Not covered

A service leg of a parcel *you sent* — the recipient redirects it, say — would now be
counted at its destination if it shows up in your feed at 7/8. I have no such sample to
check against.
